### PR TITLE
FIX: Correctly parse emails not sent from the kindle

### DIFF
--- a/emailer.py
+++ b/emailer.py
@@ -40,6 +40,8 @@ def get_email():
                     if msg.is_multipart():
                         for payload in msg.get_payload():
                             quote = payload.get_payload()
+                    else:
+                        quote = msg.get_payload()
                 # sqliteManager.write_quote_to_db(quopri.decodestring(quote).decode('utf-8'))
                 firebaseManager.write_quote_to_db(quopri.decodestring(quote).decode('utf-8'))
                 imap.store(num, '+FLAGS', '\\Deleted')

--- a/firebaseManager.py
+++ b/firebaseManager.py
@@ -22,6 +22,7 @@ DATABASE = firebase.database()
 
 def write_quote_to_db(data):
     extracted_quote = re.findall(r'"([^"]*)"', data)
+    print(extracted_quote)
     if len(extracted_quote) > 0:
         data_dict = {"timestamp": str(datetime.datetime.now()),
                      "quote": extracted_quote[0],


### PR DESCRIPTION
close #8 

Add else-statement to correctly parse emails which do not contain multipart content